### PR TITLE
Fix: List of models (support STI)

### DIFF
--- a/lib/localtower/tools.rb
+++ b/lib/localtower/tools.rb
@@ -30,11 +30,8 @@ module Localtower
       def models
         self.force_reload!
 
-        klass_parent = defined?(ApplicationRecord) ? ApplicationRecord : ActiveRecord::Base
-
-        Dir["#{Rails.root}/app/models/\*.rb"].map { |f|
-          File.basename(f, '.*').camelize.constantize
-        }.select { |klass| klass != klass_parent }.select { |klass| klass.respond_to?(:columns_hash) }
+        root_klass = defined?(ApplicationRecord) ? ApplicationRecord : ActiveRecord::Base
+        root_klass.subclasses
       end
 
       def models_presented


### PR DESCRIPTION
Hi there.

Found a small mistake when searching for models.

Current implementation does not work with subfolders.

Please review my suggestion.

*BTW*
Maybe it would be better to use: `.descendants`, but in case with STI ( for example ) we will receive different models with duplicated tables 